### PR TITLE
feat: allow custom css and themes in popouts, maybe also overlay

### DIFF
--- a/src/renderer/coremods/popoutTheming/plaintextPatches.ts
+++ b/src/renderer/coremods/popoutTheming/plaintextPatches.ts
@@ -1,0 +1,13 @@
+import { type PlaintextPatch } from "src/types";
+
+export default [
+  {
+    find: "Not injecting stylesheet,",
+    replacements: [
+      {
+        match: /\){\w+.warn\("Not injecting/,
+        replace: (suffix) => `&&null${suffix}`,
+      },
+    ],
+  },
+] as PlaintextPatch[];

--- a/src/renderer/managers/coremods.ts
+++ b/src/renderer/managers/coremods.ts
@@ -1,16 +1,16 @@
 import type { Promisable } from "type-fest";
 import { patchPlaintext } from "../modules/webpack/plaintext-patch";
 
-import { default as experimentsPlaintext } from "../coremods/experiments/plaintextPatches";
-import { default as notrackPlaintext } from "../coremods/notrack/plaintextPatches";
-import { default as noDevtoolsWarningPlaintext } from "../coremods/noDevtoolsWarning/plaintextPatches";
-import { default as messagePopover } from "../coremods/messagePopover/plaintextPatches";
-import { default as notices } from "../coremods/notices/plaintextPatches";
-import { default as contextMenu } from "../coremods/contextMenu/plaintextPatches";
-import { default as languagePlaintext } from "../coremods/language/plaintextPatches";
-import { default as settingsPlaintext } from "../coremods/settings/plaintextPatches";
-import { default as badgesPlaintext } from "../coremods/badges/plaintextPatches";
-import { default as popoutThemingPlaintext } from "../coremods/popoutTheming/plaintextPatches";
+import experimentsPlaintext from "../coremods/experiments/plaintextPatches";
+import notrackPlaintext from "../coremods/notrack/plaintextPatches";
+import noDevtoolsWarningPlaintext from "../coremods/noDevtoolsWarning/plaintextPatches";
+import messagePopover from "../coremods/messagePopover/plaintextPatches";
+import notices from "../coremods/notices/plaintextPatches";
+import contextMenu from "../coremods/contextMenu/plaintextPatches";
+import languagePlaintext from "../coremods/language/plaintextPatches";
+import settingsPlaintext from "../coremods/settings/plaintextPatches";
+import badgesPlaintext from "../coremods/badges/plaintextPatches";
+import popoutThemingPlaintext from "../coremods/popoutTheming/plaintextPatches";
 import { Logger } from "../modules/logger";
 
 const logger = Logger.api("Coremods");

--- a/src/renderer/managers/coremods.ts
+++ b/src/renderer/managers/coremods.ts
@@ -10,6 +10,7 @@ import { default as contextMenu } from "../coremods/contextMenu/plaintextPatches
 import { default as languagePlaintext } from "../coremods/language/plaintextPatches";
 import { default as settingsPlaintext } from "../coremods/settings/plaintextPatches";
 import { default as badgesPlaintext } from "../coremods/badges/plaintextPatches";
+import { default as popoutThemingPlaintext } from "../coremods/popoutTheming/plaintextPatches";
 import { Logger } from "../modules/logger";
 
 const logger = Logger.api("Coremods");
@@ -89,5 +90,6 @@ export function runPlaintextPatches(): void {
     languagePlaintext,
     settingsPlaintext,
     badgesPlaintext,
+    popoutThemingPlaintext,
   ].forEach(patchPlaintext);
 }


### PR DESCRIPTION
^^ I think allowing all css wouldnt be bad its just css in popout. I don't know why discord even does that